### PR TITLE
Add dark mode with hand-drawn theme toggle

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,5 +1,10 @@
+import { ThemeProvider } from './context/ThemeContext';
 import Index from './routes/index';
 
 export default function App() {
-  return <Index />;
+  return (
+    <ThemeProvider>
+      <Index />
+    </ThemeProvider>
+  );
 }

--- a/app/components/index/Description.tsx
+++ b/app/components/index/Description.tsx
@@ -1,12 +1,20 @@
 import { RoughNotation } from 'react-rough-notation';
 
-import { LIGHT_GREY } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
 import { STROKE_WIDTH } from '../../constants/roughNotationConstants';
 
 function Description() {
+  const { colors } = useTheme();
+
   return (
-    <RoughNotation type="box" color={LIGHT_GREY} strokeWidth={STROKE_WIDTH}>
-      <b>mission software engineer @ anduril industries</b>
+    <RoughNotation
+      type="box"
+      color={colors.annotation}
+      strokeWidth={STROKE_WIDTH}
+    >
+      <b style={{ color: colors.text }}>
+        mission software engineer @ anduril industries
+      </b>
     </RoughNotation>
   );
 }

--- a/app/components/index/ExternalLink.tsx
+++ b/app/components/index/ExternalLink.tsx
@@ -1,6 +1,6 @@
 import { RoughNotation } from 'react-rough-notation';
 
-import { GREY, LIGHT_GREY } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
 import { STROKE_WIDTH } from '../../constants/roughNotationConstants';
 
 type Props = {
@@ -9,14 +9,16 @@ type Props = {
 };
 
 function ExternalLink({ children, to }: Props) {
+  const { colors } = useTheme();
+
   return (
     <RoughNotation
       type="underline"
-      color={LIGHT_GREY}
+      color={colors.annotation}
       strokeWidth={STROKE_WIDTH}
     >
       <a
-        style={{ color: GREY, textDecoration: 'none' }}
+        style={{ color: colors.text, textDecoration: 'none' }}
         href={to}
         target="_blank"
         rel="noreferrer"

--- a/app/components/index/Header.tsx
+++ b/app/components/index/Header.tsx
@@ -1,10 +1,12 @@
-import { GREY } from '../../constants/colors';
+import { useTheme } from '../../context/ThemeContext';
 
 function Header() {
+  const { colors } = useTheme();
+
   return (
     <h2>
       <span>
-        <b style={{ color: GREY }}>john gamboa</b>
+        <b style={{ color: colors.text }}>john gamboa</b>
       </span>
     </h2>
   );

--- a/app/components/index/Links.tsx
+++ b/app/components/index/Links.tsx
@@ -1,8 +1,11 @@
+import { useTheme } from '../../context/ThemeContext';
 import ExternalLink from './ExternalLink';
 
 function Links() {
+  const { colors } = useTheme();
+
   return (
-    <p>
+    <p style={{ color: colors.text }}>
       <span>check out my </span>
       <ExternalLink to="https://www.linkedin.com/in/johnhadriangamboa/">
         <b>LinkedIn</b>

--- a/app/components/index/ThemeToggle.tsx
+++ b/app/components/index/ThemeToggle.tsx
@@ -1,0 +1,97 @@
+import { useTheme } from '../../context/ThemeContext';
+
+function SunIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 3v2M12 19v2M3 12h2M19 12h2" />
+      <path d="M5.5 5.5l1.4 1.4M17.1 17.1l1.4 1.4M5.5 18.5l1.4-1.4M17.1 6.9l1.4-1.4" />
+    </svg>
+  );
+}
+
+function MoonIcon({ color }: { color: string }) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24">
+      <path d="M12 2a10 10 0 1 0 10 10 7 10 0 1 1-10-10" fill={color} />
+    </svg>
+  );
+}
+
+function ThemeToggle() {
+  const { isDark, toggleTheme, colors } = useTheme();
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '20px',
+        right: '20px',
+        zIndex: 1000,
+      }}
+    >
+      <button
+        onClick={toggleTheme}
+        aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+        style={{
+          width: '60px',
+          height: '30px',
+          borderRadius: '15px',
+          border: `2px solid ${colors.text}`,
+          background: isDark ? '#1c1c1c' : '#fefefe',
+          cursor: 'pointer',
+          position: 'relative',
+          padding: '0 6px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          outline: 'none',
+          transition: 'background 0.3s',
+        }}
+      >
+        <span
+          style={{
+            opacity: isDark ? 0.3 : 1,
+            transition: 'opacity 0.3s',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <SunIcon color={isDark ? '#b8b8b8' : '#949494'} />
+        </span>
+        <span
+          style={{
+            opacity: isDark ? 1 : 0.3,
+            transition: 'opacity 0.3s',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <MoonIcon color={isDark ? '#b8b8b8' : '#949494'} />
+        </span>
+        <div
+          style={{
+            position: 'absolute',
+            left: isDark ? 'calc(100% - 24px)' : '4px',
+            transition: 'left 0.25s ease',
+            width: '20px',
+            height: '20px',
+            borderRadius: '50%',
+            background: colors.text,
+            pointerEvents: 'none',
+          }}
+        />
+      </button>
+    </div>
+  );
+}
+
+export default ThemeToggle;

--- a/app/constants/colors.ts
+++ b/app/constants/colors.ts
@@ -1,3 +1,7 @@
 export const WHITE = '#fefefe';
 export const GREY = '#949494';
 export const LIGHT_GREY = '#d3d3d3';
+
+export const DARK_BG = '#1c1c1c';
+export const DARK_TEXT = '#b8b8b8';
+export const DARK_ANNOTATION = '#4a4a4a';

--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -1,0 +1,80 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+} from 'react';
+
+import {
+  WHITE,
+  GREY,
+  LIGHT_GREY,
+  DARK_BG,
+  DARK_TEXT,
+  DARK_ANNOTATION,
+} from '../constants/colors';
+
+type Theme = 'light' | 'dark';
+
+type ThemeColors = {
+  background: string;
+  text: string;
+  annotation: string;
+};
+
+type ThemeContextType = {
+  theme: Theme;
+  isDark: boolean;
+  toggleTheme: () => void;
+  colors: ThemeColors;
+};
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const LIGHT_COLORS: ThemeColors = {
+  background: WHITE,
+  text: GREY,
+  annotation: LIGHT_GREY,
+};
+
+const DARK_COLORS: ThemeColors = {
+  background: DARK_BG,
+  text: DARK_TEXT,
+  annotation: DARK_ANNOTATION,
+};
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark' || stored === 'light') return stored;
+    }
+    return 'dark';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('theme', theme);
+    document.body.style.backgroundColor = theme === 'dark' ? DARK_BG : WHITE;
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const colors = theme === 'dark' ? DARK_COLORS : LIGHT_COLORS;
+
+  return (
+    <ThemeContext.Provider
+      value={{ theme, isDark: theme === 'dark', toggleTheme, colors }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error('useTheme must be used within ThemeProvider');
+  return context;
+}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -4,6 +4,7 @@ import Header from '../components/index/Header';
 import Description from '../components/index/Description';
 import Links from '../components/index/Links';
 import Circle from '../components/index/Circle';
+import ThemeToggle from '../components/index/ThemeToggle';
 
 export default function Index() {
   return (
@@ -26,6 +27,7 @@ export default function Index() {
           <Links />
         </div>
       </div>
+      <ThemeToggle />
     </RoughNotationGroup>
   );
 }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       font-size: 16px;
       background-color: #fefefe;
       user-select: none;
+      transition: background-color 0.3s;
     "
   >
     <div id="root"></div>


### PR DESCRIPTION
Add dark mode support with a hand-drawn aesthetic toggle switch.

## Changes
- **ThemeContext** — new React context managing light/dark state, persisted to `localStorage`. Defaults to dark mode. Updates `document.body.backgroundColor`.
- **ThemeToggle** — fixed-position toggle at bottom-right. Rounded pill with SVG sun (light mode) and filled crescent moon (dark mode) icons, sliding thumb, opacity transitions.
- **colors.ts** — added dark mode color constants (`DARK_BG`, `DARK_TEXT`, `DARK_ANNOTATION`).
- **Header, Description, ExternalLink, Links** — now consume `useTheme()` to render with correct text/annotation colors.
- **index.html** — added `transition: background-color 0.3s` for smooth theme switching.
- **Dark colors:** bg `#1c1c1c`, text `#b8b8b8`, annotation `#4a4a4a`